### PR TITLE
Fix episodes matching the wrong seasons and being placed in "strayvideos"

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/opforjellyfin.iml" filepath="$PROJECT_DIR$/.idea/opforjellyfin.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/opforjellyfin.iml
+++ b/.idea/opforjellyfin.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -1,0 +1,85 @@
+package cmd
+
+// import (
+// 	"fmt"
+// 	"github.com/spf13/cobra"
+// 	"opforjellyfin/internal/logger"
+// 	"opforjellyfin/internal/matcher"
+// 	"opforjellyfin/internal/metadata"
+// 	"opforjellyfin/internal/scraper"
+// 	"opforjellyfin/internal/shared"
+// 	"opforjellyfin/internal/torrent"
+// 	"opforjellyfin/internal/ui"
+// 	"os"
+// 	"strconv"
+// )
+
+// var (
+// 	forceChapter string
+// )
+
+// var importCmd = &cobra.Command{
+// 	Use:   "import [folder...]",
+// 	Short: "Import One Pace episodes from one or more files/folders. By default, it searches the strayvideos files.",
+// 	Run: func(cmd *cobra.Command, args []string) {
+
+// add spinner
+// spinner := ui.NewSpinner("🗃️ Preparing import.. ", ui.Animations["MetaFetcher"])
+
+// sourcePaths := make([]string, 0, max(len(args), 1))
+
+// if len(args) < 1 {
+// 	sourcePaths[0] = "strayvideos"
+// }
+
+// cfg := shared.LoadConfig()
+// if cfg.TargetDir == "" {
+// 	logger.Log(true, "⚠️ No target directory set. Use 'setDir <path>' first.")
+// 	return
+// }
+
+// if cfg.Source.BaseURL == "" {
+// 	logger.Log(true, "No valid scraper configuration found. Please run 'sync'")
+// }
+
+// // stop spinner
+// spinner.Stop()
+// var matches map[string]shared.EpisodeData
+
+// for _, arg := range args {
+
+// 	chapterRange := "0-0"
+
+// 	// maybe rewrite this part
+// 	if forceChapter != "" {
+// 		if len(args) > 1 {
+// 			logger.Log(true, "❌ --forceChapter may only be used with a single folder/file")
+// 		}
+// 		chapterRange = forceChapter
+// 	}
+
+// 	//dKey := ui.StyleFactory(fmt.Sprintf("%4d", match.DownloadKey), ui.Style.Pink)
+// 	//title := ui.StyleFactory(match.TorrentName, ui.Style.LBlue)
+
+// 	//logger.Log(true, "🔍 Matched DownloadKey %s → %s (%s) [%s]", dKey, title, match.Quality, match.ChapterRange)
+// 	//logger.Log(true, "🎬 Starting download: %s (%s)\n", match.TorrentName, match.Quality)
+// 	//matches = append(matches, *match)
+// }
+
+// if len(matches) == 0 {
+// 	fmt.Println("⚠️  No files to process.")
+// 	os.Exit(0)
+// }
+
+// // Load metadata index once
+// metadataIndex := metadata.LoadMetadataCache()
+
+// matcher.ProcessTorrentFiles(tmpDir, cfg.TargetDir, td, metadataIndex)
+// 	},
+// }
+
+// func init() {
+// 	importCmd.Flags().StringVar(&forceChapter, "forceChapter", "", "Override chapter range (only for single downloadKey)")
+
+// 	rootCmd.AddCommand(importCmd)
+// }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -24,6 +24,7 @@ var (
 
 	onlySpecials bool
 	verboseList  bool
+	sortNewest	 bool
 
 	alternate bool
 )
@@ -57,13 +58,23 @@ var listCmd = &cobra.Command{
 			}
 		}
 
-		// Sort by DownloadKey, then seeders descending
-		sort.SliceStable(filtered, func(i, j int) bool {
-			if filtered[i].DownloadKey == filtered[j].DownloadKey {
-				return filtered[i].Seeders > filtered[j].Seeders
-			}
-			return filtered[i].DownloadKey < filtered[j].DownloadKey
-		})
+		if sortNewest {
+			// Sort by date descending, then seeders descending
+			sort.SliceStable(filtered, func(i, j int) bool {
+				if filtered[i].Date.Equal(filtered[j].Date) {
+					return filtered[i].Seeders > filtered[j].Seeders
+				}
+				return filtered[i].Date.After(filtered[j].Date)
+			})
+		} else {
+			// Sort by DownloadKey, then seeders descending
+			sort.SliceStable(filtered, func(i, j int) bool {
+				if filtered[i].DownloadKey == filtered[j].DownloadKey {
+					return filtered[i].Seeders > filtered[j].Seeders
+				}
+				return filtered[i].DownloadKey < filtered[j].DownloadKey
+			})
+		}
 
 		spinner.Stop()
 
@@ -138,8 +149,15 @@ func renderRow(t shared.TorrentEntry) {
 	// styling and render
 	truncatedTitle := ui.AnsiPadRight(t.TorrentName, 30)
 
+	var dateFmt string
+	if t.Date.IsZero() {
+		dateFmt = "N/A"
+	} else {
+		dateFmt = t.Date.Format("2006-01-02 15:04:05")
+	}
+
 	row := ui.RenderRow(
-		"%s - %s: %s Have? %s | Meta: %s | %-9s | %s | %s seeders | %s",
+		"%s - %s: %s Have? %s | Meta: %s | %-9s | %s | %s seeders | %s | %s",
 		alternate,
 		ui.StyleFactory("DKEY", ui.Style.LBlue),
 		ui.StyleFactory(fmt.Sprintf("%4d", t.DownloadKey), ui.Style.Pink),
@@ -149,7 +167,8 @@ func renderRow(t shared.TorrentEntry) {
 		t.ChapterRange,
 		ui.AnsiPadLeft(ui.StyleByRange(t.Quality, 400, 1000), 5),
 		ui.AnsiPadLeft(ui.StyleByRange(t.Seeders, 0, 10), 3),
-		t.Date,
+		t.FileSize,
+		dateFmt,
 	)
 
 	// set flag
@@ -173,8 +192,15 @@ func renderVerboseRow(t shared.TorrentEntry) {
 
 	fullTitle := ui.AnsiPadRight(t.Title, 60)
 
+	var dateFmt string
+	if t.Date.IsZero() {
+		dateFmt = "N/A"
+	} else {
+		dateFmt = t.Date.Format("2006-01-02 15:04:05")
+	}
+
 	row := ui.RenderRow(
-		"%s - %s: %s H:%s M:%s | %s seeders | %s",
+		"%s - %s: %s H:%s M:%s | %s seeders | %s | %s",
 		alternate,
 		ui.StyleFactory("DKEY", ui.Style.LBlue),
 		ui.StyleFactory(fmt.Sprintf("%4d", t.DownloadKey), ui.Style.Pink),
@@ -182,7 +208,8 @@ func renderVerboseRow(t shared.TorrentEntry) {
 		haveMark,
 		metaMark,
 		ui.AnsiPadLeft(ui.StyleByRange(t.Seeders, 0, 10), 3),
-		t.Date,
+		t.FileSize,
+		dateFmt,
 	)
 
 	alternate = !alternate
@@ -198,5 +225,6 @@ func init() {
 
 	listCmd.Flags().BoolVarP(&onlySpecials, "specials", "s", false, "Show only specials")
 	listCmd.Flags().BoolVarP(&verboseList, "verbose", "v", false, "Show full titles")
+	listCmd.Flags().BoolVarP(&sortNewest, "newest", "n", false, "Sort by newest upload date")
 	rootCmd.AddCommand(listCmd)
 }

--- a/internal/matcher/matcher.go
+++ b/internal/matcher/matcher.go
@@ -14,7 +14,7 @@ import (
 
 // Matches video-file to metadata, then places it
 // No mutex needed here - shared.SafeMoveFile handles all locking
-func MatchAndPlaceVideo(videoPath, defaultDir string, index *shared.MetadataIndex, ogcr string) (string, error) {
+func MatchAndPlaceVideo(videoPath, defaultDir string, index *shared.MetadataIndex, td *shared.TorrentDownload) (string, error) {
 
 	if _, err := os.Stat(videoPath); os.IsNotExist(err) {
 		return "", nil
@@ -25,7 +25,7 @@ func MatchAndPlaceVideo(videoPath, defaultDir string, index *shared.MetadataInde
 	logger.Log(false, "Placing filename : %s", fileName)
 
 	// strict
-	dstPathNoSuffix := findMetadataMatch(fileName, index, ogcr)
+	dstPathNoSuffix := findMetadataMatch(fileName, index, td)
 
 	logger.Log(false, "dstPath for fileName %s will be %s", fileName, dstPathNoSuffix)
 
@@ -87,13 +87,13 @@ func MatchAndPlaceVideo(videoPath, defaultDir string, index *shared.MetadataInde
 }
 
 // returns directory to place file, without suffix
-func findMetadataMatch(fileName string, index *shared.MetadataIndex, ogcr string) string {
+func findMetadataMatch(fileName string, index *shared.MetadataIndex, td *shared.TorrentDownload) string {
 
 	cfg := shared.LoadConfig()
 	baseDir := cfg.TargetDir
 
 	// strayfolder for unmatched videos
-	strayfolder := filepath.Join(baseDir, "strayvideos", ogcr, fileName)
+	strayfolder := filepath.Join(baseDir, "strayvideos", td.ChapterRange, fileName)
 	// finds season containing chapterRange, returns the seasonFolderName and seasonIndex
 	// uses ogcr to find correct season even if its a bundle
 	seasonStartIdx := -1
@@ -106,17 +106,22 @@ func findMetadataMatch(fileName string, index *shared.MetadataIndex, ogcr string
 	// some seasons have overlapping chapters (i.e. The Trials of Koby-Meppo cover pages span Ch. 83-119)
 	for seasonStartIdx < len(sortedIndex.Seasons) {
 
-		seasonFolderName, seasonIndex, startIdx := findSeasonForChapter(ogcr, sortedIndex, seasonStartIdx)
+		seasonFolderName, seasonIndex, startIdx := findSeasonForChapter(td.ChapterRange, sortedIndex, seasonStartIdx)
 		seasonStartIdx = startIdx
 
 		if seasonFolderName == "" {
 			logger.Log(false, "findMetaDataMatch: failed to find Season-folder")
 			return strayfolder
 		}
-		logger.Log(false, "season found for: %s for range %s", seasonFolderName, ogcr)
+		logger.Log(false, "season found for: %s for range %s", seasonFolderName, td.ChapterRange)
+
+		var filters []string
+		if td.Entry.IsExtended {
+			filters = append(filters, "extended")
+		}
 
 		// searches the seasonIndex for matching title for chapterRange, tries ogcr first for single-episode seasons
-		newFileName = findTitleForChapter(ogcr, seasonIndex)
+		newFileName = findTitleForChapter(td.ChapterRange, seasonIndex, filters...)
 		if newFileName == "" {
 			// if first fails, extract specific chapterRange from fileName
 			chapterRange := shared.ExtractChapterRangeFromTitle(fileName)
@@ -132,18 +137,30 @@ func findMetadataMatch(fileName string, index *shared.MetadataIndex, ogcr string
 				logger.Log(false, "findMetaDataMatch - rough extracted chapterNum: %s", chapterNum)
 
 				if isRange {
-					newFileName = findTitleForChapter(chapterNum, seasonIndex)
+					newFileName = findTitleForChapter(chapterNum, seasonIndex, filters...)
 				} else {
 					// build a matching string from season and rough chapter, eg: seasonNum = 3 and chapternum = 05 => S03E05
 					epKey := fmt.Sprintf("S%sE%s", seasonNum, chapterNum)
-					newFileName = findTitleRough(epKey, seasonIndex)
+					newFileName = findTitleRough(epKey, seasonIndex, filters...)
 				}
 			} else {
 				// if extraction succeeded, find title from chapterRange
-				newFileName = findTitleForChapter(chapterRange, seasonIndex)
+				newFileName = findTitleForChapter(chapterRange, seasonIndex, filters...)
 			}
 		} else {
-			logger.Log(false, "Title match found: ChapterKey: %s - EpisodeTitle: %s", ogcr, fileName)
+			logger.Log(false, "Title match found: ChapterKey: %s - EpisodeTitle: %s", td.ChapterRange, fileName)
+		}
+
+		if newFileName == "" {
+			matches := shared.FindMatchingEpisodes(td.ChapterRange, index)
+			// Pick the first match that belongs to the same season
+			for _, m := range matches {
+				if m.SeasonKey == seasonFolderName && m.EpisodeTitle != "" {
+					logger.Log(false, "findMetaDataMatch: overlap match found: %s -> %s (%d)", td.ChapterRange, m.EpisodeTitle, m.MatchType)
+					newFileName = m.EpisodeTitle
+					break
+				}
+			}
 		}
 
 		seasonDir = filepath.Join(baseDir, seasonFolderName)
@@ -166,17 +183,33 @@ func findMetadataMatch(fileName string, index *shared.MetadataIndex, ogcr string
 }
 
 // exact match, returns title from metadataindex using chapterKey.
-func findTitleForChapter(chapterKey string, sindex shared.SeasonIndex) string {
+func findTitleForChapter(chapterKey string, sindex shared.SeasonIndex, nameFilters ...string) string {
 	normKey := shared.NormalizeDash(chapterKey)
 
 	logger.Log(false, "findEpisodeKeyForChapter: chapterKey: %s - normKey: %s ", chapterKey, normKey)
 
-	for epRange, ep := range sindex.EpisodeRange {
+	for epRange, epData := range sindex.EpisodeRange {
 		epKey := shared.NormalizeDash(epRange)
 		logger.Log(false, "checkingTitle for chapter[%s]: [%s]", normKey, epKey)
 		if epKey == normKey {
-			logger.Log(false, "foundTitle for chapter[%s]: [%s] - %s", normKey, epKey, ep.Title)
-			return ep.Title
+			var bestMatch string
+			bestCount := -1
+
+			for _, ep := range epData {
+				filterCount := 0
+				for _, nameFilter := range nameFilters {
+					if strings.Contains(strings.ToLower(ep.Title), strings.ToLower(nameFilter)) {
+						filterCount++
+					}
+				}
+				if filterCount > bestCount {
+					bestCount = filterCount
+					bestMatch = ep.Title
+				}
+			}
+			logger.Log(false, "foundTitle for chapter[%s]: [%s] - %s", normKey, epKey, bestMatch)
+
+			return bestMatch
 		}
 	}
 
@@ -186,7 +219,8 @@ func findTitleForChapter(chapterKey string, sindex shared.SeasonIndex) string {
 	return ""
 }
 
-// finds the season a ChapterKey belongs to. returns the season name as a string, also returns the whole SeasonIndex struct
+// finds the season a ChapterKey belongs to. returns the season name as a string, also returns the whole SeasonIndex struct.
+// When multiple seasons contain the range (e.g. overlapping recap seasons), picks the narrowest fit.
 func findSeasonForChapter(chapterKey string, index *shared.SortedMetadataIndex, startIdx int) (string, shared.SeasonIndex, int) {
 	chStart, chEnd := shared.ParseRange(chapterKey)
 
@@ -204,12 +238,29 @@ func findSeasonForChapter(chapterKey string, index *shared.SortedMetadataIndex, 
 }
 
 // rough finder
-func findTitleRough(epKey string, sindex shared.SeasonIndex) string {
+func findTitleRough(epKey string, sindex shared.SeasonIndex, nameFilters ...string) string {
 
-	for _, ep := range sindex.EpisodeRange {
-		if strings.Contains(ep.Title, epKey) {
-			logger.Log(false, "roughFindTitle match found: %s > %s", epKey, ep.Title)
-			return ep.Title
+	for _, epData := range sindex.EpisodeRange {
+		bestMatch := ""
+		bestCount := -1
+
+		for _, ep := range epData {
+			if strings.Contains(ep.Title, epKey) {
+				filterCount := 0
+				for _, nameFilter := range nameFilters {
+					if strings.Contains(strings.ToLower(ep.Title), strings.ToLower(nameFilter)) {
+						filterCount++
+					}
+				}
+				if filterCount > bestCount {
+					bestCount = filterCount
+					bestMatch = ep.Title
+				}
+			}
+		}
+		if bestMatch != "" {
+			logger.Log(false, "findTitleRough found rough match for epKey %s: %s", epKey, bestMatch)
+			return bestMatch
 		}
 	}
 

--- a/internal/matcher/processfile.go
+++ b/internal/matcher/processfile.go
@@ -9,17 +9,16 @@ import (
 	"strings"
 )
 
-// walks through downloaded files and tries to place them in correct dir
-func ProcessTorrentFiles(tmpDir, outDir string, td *shared.TorrentDownload, index *shared.MetadataIndex) {
+func ProcessVideoFiles(srcDir, outDir string, td *shared.TorrentDownload, index *shared.MetadataIndex) {
 	filesChecked := 0
 	filesPlaced := 0
 	var lastError error
 
 	// collect all paths
-	td.PlacementProgress = fmt.Sprintf("🔧 Finding files to place %s", tmpDir)
+	td.PlacementProgress = fmt.Sprintf("🔧 Finding files to place %s", srcDir)
 
 	var vidPaths []string
-	err := filepath.Walk(tmpDir, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			logger.Log(true, "Failed walking file: %v", err)
 			return nil
@@ -58,7 +57,7 @@ func ProcessTorrentFiles(tmpDir, outDir string, td *shared.TorrentDownload, inde
 		td.PlacementProgress = fmt.Sprintf("🔧 Placing ➝ %d/%d - %s", (filesPlaced + 1), len(vidPaths), readablePath)
 
 		// match and place
-		msg, err := MatchAndPlaceVideo(path, outDir, index, td.ChapterRange)
+		msg, err := MatchAndPlaceVideo(path, outDir, index, td)
 		if err != nil {
 			logger.Log(true, "Error placing file: %v", err)
 			lastError = err
@@ -67,6 +66,11 @@ func ProcessTorrentFiles(tmpDir, outDir string, td *shared.TorrentDownload, inde
 			//save msg for final summary
 			td.PlacementFull = append(td.PlacementFull, msg)
 			shared.SaveTorrentDownload(td)
+			// var intf interface{} = *td
+			// switch v := intf.(type) {
+			// case shared.TorrentDownload:
+			// 	shared.SaveTorrentDownload(&v)
+			// }
 		}
 	}
 
@@ -90,4 +94,9 @@ func ProcessTorrentFiles(tmpDir, outDir string, td *shared.TorrentDownload, inde
 
 	td.MarkPlaced(placedMsg)
 	logger.Log(false, "File placement done: %d checked, %d placed", filesChecked, filesPlaced)
+}
+
+// walks through downloaded files and tries to place them in correct dir
+func ProcessTorrentFiles(tmpDir, outDir string, td *shared.TorrentDownload, index *shared.MetadataIndex) {
+	ProcessVideoFiles(tmpDir, outDir, td, index)
 }

--- a/internal/metadata/indexbuilder.go
+++ b/internal/metadata/indexbuilder.go
@@ -46,13 +46,19 @@ func buildIndexFromDir(baseDir string) (*shared.MetadataIndex, error) {
 		// check if SeasonIndex is there
 		if _, exists := index.Seasons[seasonKey]; !exists {
 			index.Seasons[seasonKey] = shared.SeasonIndex{
-				EpisodeRange: make(map[string]shared.EpisodeData),
+				EpisodeRange: make(map[string][]shared.EpisodeData),
 			}
 		}
-		// just store title, use baseDir+seasonKey+epTitle+mp4/mkv for storing
-		index.Seasons[seasonKey].EpisodeRange[normalized] = shared.EpisodeData{
-			Title: epTitle,
+
+		if _, exists := index.Seasons[seasonKey].EpisodeRange[normalized]; !exists {
+			index.Seasons[seasonKey].EpisodeRange[normalized] = []shared.EpisodeData{}
 		}
+
+		// just store title, use baseDir+seasonKey+epTitle+mp4/mkv for storing
+		index.Seasons[seasonKey].EpisodeRange[normalized] = append(index.Seasons[seasonKey].EpisodeRange[normalized], 
+			shared.EpisodeData{
+				Title: epTitle,
+		})
 
 		return nil
 	})

--- a/internal/metadata/status.go
+++ b/internal/metadata/status.go
@@ -18,37 +18,54 @@ func HaveVideoStatus(chapterRange string) int {
 	cfg := shared.LoadConfig()
 	baseDir := cfg.TargetDir
 
-	for seasonKey, season := range index.Seasons {
-		seasonDir := filepath.Join(baseDir, seasonKey)
+	matches := shared.FindMatchingEpisodes(chapterRange, index)
+	if len(matches) == 0 {
+		logger.Log(false, "HaveVideoStatus: No metadata matches found for chapterRange %s", chapterRange)
+		return 0
+	}
 
-		if season.Range == chapterRange {
-			v, n := CountVideosAndTotal(seasonDir)
-			logger.Log(false, "HaveVideoStatus: counted %d videos and %d nfos for seasonKey: %s", v, n, seasonKey)
-			if v == 0 {
-				return 0
-			}
-
-			if v < n {
-				return 1
-			}
-
-			return 2
+	// Season-level match (bundle torrent or exact season)
+	if matches[0].EpisodeRange == "" {
+		seasonDir := filepath.Join(baseDir, matches[0].SeasonKey)
+		v, n := CountVideosAndTotal(seasonDir)
+		logger.Log(false, "HaveVideoStatus(%s): counted %d videos and %d nfos for seasonKey: %s", chapterRange, v, n, matches[0].SeasonKey)
+		if v == 0 {
+			return 0
 		}
+		if v < n {
+			return 1
+		}
+		return 2
+	}
 
-		for epRange, epData := range season.EpisodeRange {
-			if epRange == chapterRange {
-				videoPathMP4 := filepath.Join(seasonDir, epData.Title+".mp4")
-				videoPathMKV := filepath.Join(seasonDir, epData.Title+".mkv")
+	// Episode-level matches: check if video files exist for each matched episode
+	haveCount := make(map[string]int)
+	for _, m := range matches {
+		seasonDir := filepath.Join(baseDir, m.SeasonKey)
+		videoPathMP4 := filepath.Join(seasonDir, m.EpisodeTitle+".mp4")
+		videoPathMKV := filepath.Join(seasonDir, m.EpisodeTitle+".mkv")
 
-				if shared.FileExists(videoPathMP4) || shared.FileExists(videoPathMKV) {
-					return 2
-				}
-			}
-
+		if shared.FileExists(videoPathMP4) || shared.FileExists(videoPathMKV) {
+			haveCount[m.EpisodeRange]++
+		} else if count, exists := haveCount[m.EpisodeRange]; exists && count > 0 {
+			haveCount[m.EpisodeRange]++
 		}
 	}
 
-	return 0
+	haveSum := 0
+	for _, count := range haveCount {
+		haveSum += count
+	}
+
+	logger.Log(false, "HaveVideoStatus(%s): episode match found - haveCount: %d, totalMatches: %d", chapterRange, haveSum, len(matches))
+
+	if haveSum == 0 {
+		return 0
+	}
+	if haveSum < len(matches) {
+		return 1
+	}
+	return 2
 }
 
 // HaveMetadata checks if metadata exists for given chapterRange.
@@ -58,23 +75,8 @@ func HaveMetadata(chapterRange string) bool {
 	}
 
 	LoadMetadataCache()
-	norm := shared.NormalizeDash(chapterRange)
-
-	for _, season := range metadataCache.Seasons {
-		// season range match instantly
-		if shared.NormalizeDash(season.Range) == norm {
-			return true
-		}
-
-		// match individual episodes
-		for epRange := range season.EpisodeRange {
-			if shared.NormalizeDash(epRange) == norm {
-				return true
-			}
-		}
-	}
-
-	return false
+	matches := shared.FindMatchingEpisodes(chapterRange, metadataCache)
+	return len(matches) > 0
 }
 
 // video and .nfo file counter. Returns: number of videos matched with episode .nfo file, number of episode .nfo files

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/PuerkitoBio/goquery"
 )
@@ -36,32 +37,14 @@ func FetchTorrents(cfg shared.Config) ([]shared.TorrentEntry, error) {
 	for {
 		searchURL := fmt.Sprintf(baseURL+srcConfig.SearchPathTemplate, srcConfig.SearchQuery, page)
 
-		resp, err := http.Get(searchURL)
+		entries, done, err := fetchPage(searchURL, &srcConfig, baseURL)
 		if err != nil {
 			return nil, err
 		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		rawEntries = append(rawEntries, entries...)
+		if done {
+			break
 		}
-
-		doc, err := goquery.NewDocumentFromReader(resp.Body)
-		if err != nil {
-			return nil, err
-		}
-
-		rows := doc.Find(srcConfig.RowSelector)
-		if rows.Length() == 0 {
-			break // finito
-		}
-
-		rows.Each(func(i int, s *goquery.Selection) {
-			entry, ok := parseRow(s, &srcConfig, baseURL)
-			if ok {
-				rawEntries = append(rawEntries, entry)
-			}
-		})
 
 		page++
 	}
@@ -70,13 +53,61 @@ func FetchTorrents(cfg shared.Config) ([]shared.TorrentEntry, error) {
 	return processEntries(rawEntries), nil
 }
 
+// fetchPage retrieves and parses a single search results page.
+// Returns the parsed entries, whether there are no more pages, and any error.
+func fetchPage(searchURL string, config *shared.ScraperConfig, baseURL string) ([]shared.TorrentEntry, bool, error) {
+	resp, err := http.Get(searchURL)
+	if err != nil {
+		return nil, false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, false, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	doc, err := goquery.NewDocumentFromReader(resp.Body)
+	if err != nil {
+		return nil, false, err
+	}
+
+	rows := doc.Find(config.RowSelector)
+	if rows.Length() == 0 {
+		return nil, true, nil
+	}
+
+	var entries []shared.TorrentEntry
+	rows.Each(func(i int, s *goquery.Selection) {
+		entry, ok := parseRow(s, config, baseURL)
+		if ok {
+			entries = append(entries, entry)
+		}
+	})
+
+	return entries, false, nil
+}
+
 // parseRow extracts torrent data from a table row using the scraper config
 func parseRow(s *goquery.Selection, config *shared.ScraperConfig, baseURL string) (shared.TorrentEntry, bool) {
 	// Extract fields using configured selectors
 	title := s.Find(config.Fields.Title).Text()
 	seedersStr := s.Find(config.Fields.Seeders).Text()
 	torrentLink, _ := s.Find(config.Fields.TorrentLink).Attr("href")
-	date := s.Find(config.Fields.UploadDate).Text()
+	dateNode := s.Find(config.Fields.UploadDate)
+	fileSizeStr := s.Find(config.Fields.FileSize).Text()
+	dateStr, attrExists := dateNode.Attr("data-timestamp")
+	var date time.Time
+	var err error
+	if attrExists {
+		dateTimestamp, _ := strconv.Atoi(dateStr)
+		date = time.Unix(int64(dateTimestamp), 0)
+	} else {
+		dateStr = dateNode.Text()
+		date, err = time.Parse("2006-01-02 15:04", dateStr)
+		if err != nil {
+			date = time.Time{} // zero value if parsing fails
+		}
+	}
 
 	// Validate based on config
 	if config.Validation.RequiredInTitle != "" {
@@ -130,6 +161,7 @@ func parseRow(s *goquery.Selection, config *shared.ScraperConfig, baseURL string
 		MetaDataAvail: metaDataAvail,
 		HaveIt:        videoStatus,
 		Date:          date,
+		FileSize:			 fileSizeStr,
 		IsExtended:    isExtended,
 	}, true
 }

--- a/internal/shared/downloads.go
+++ b/internal/shared/downloads.go
@@ -69,8 +69,18 @@ func CleanupTempDirs() error {
 }
 
 // helper
-func (td *TorrentDownload) MarkPlaced(msg string) {
-	td.PlacementProgress = msg
-	td.Placed = true
-	SaveTorrentDownload(td)
+func (fp *FilePlacement) MarkPlaced(msg string) {
+	fp.PlacementProgress = msg
+	fp.Placed = true
+	var intf interface{} = *fp
+	switch v := intf.(type) {
+	case TorrentDownload:
+		SaveTorrentDownload(&v)
+	}
 }
+
+//func (td *TorrentDownload) MarkPlaced(msg string) {
+//	td.PlacementProgress = msg
+//	td.Placed = true
+//	SaveTorrentDownload(td)
+//}

--- a/internal/shared/helpers.go
+++ b/internal/shared/helpers.go
@@ -1,8 +1,48 @@
 package shared
 
+import (
+	"regexp"
+	"sort"
+	"strconv"
+)
+
 // used by Metadata.go
 func RangesOverlap(a1, a2, b1, b2 int) bool {
 	return a1 <= b2 && b1 <= a2
 }
 
 // file
+
+// sorts season keys of the format "Season \d+"
+// "Specials" season special case, equivalent to "Season 0"
+func sortKeysByIntSuffix(seasonNames []string) []string {
+	re := regexp.MustCompile(`(\d+)$`)
+	sort.Slice(seasonNames, func(i, j int) bool {
+		// extract season number, convert to int, and compare
+		a := re.FindString(seasonNames[i])
+		b := re.FindString(seasonNames[j])
+		ai, _ := strconv.Atoi(a)
+		bi, _ := strconv.Atoi(b)
+		return ai < bi
+	})
+	return seasonNames
+}
+
+// SortMetadataSeasons convert a MetadataIndex into an equivalent sorted version
+func SortMetadataSeasons(index *MetadataIndex) *SortedMetadataIndex {
+	seasonNames := make([]string, 0, len(index.Seasons))
+	for k := range index.Seasons {
+		seasonNames = append(seasonNames, k)
+	}
+	seasonNames = sortKeysByIntSuffix(seasonNames)
+
+	result := &SortedMetadataIndex{
+		Seasons: make([]SeasonEntry, 0, len(index.Seasons)),
+	}
+
+	for _, k := range seasonNames {
+		result.Seasons = append(result.Seasons, SeasonEntry{k, index.Seasons[k]})
+	}
+
+	return result
+}

--- a/internal/shared/helpers.go
+++ b/internal/shared/helpers.go
@@ -1,12 +1,15 @@
 package shared
 
 import (
+	"fmt"
+	"opforjellyfin/internal/logger"
 	"regexp"
 	"sort"
 	"strconv"
+	"strings"
 )
 
-// used by Metadata.go
+// RangesOverlap returns true if two ranges overlap at all
 func RangesOverlap(a1, a2, b1, b2 int) bool {
 	return a1 <= b2 && b1 <= a2
 }
@@ -45,4 +48,145 @@ func SortMetadataSeasons(index *MetadataIndex) *SortedMetadataIndex {
 	}
 
 	return result
+}
+
+
+// NormalizeRange strips leading zeros and normalizes dashes: "001-007" -> "1-7"
+func NormalizeRange(r string) string {
+	r = NormalizeDash(r)
+	a, b := ParseRange(r)
+	if a < 0 || b < 0 {
+		return r
+	}
+	return fmt.Sprintf("%d-%d", a, b)
+}
+
+// RangeContains returns true if outer fully contains inner
+func RangeContains(outerStart, outerEnd, innerStart, innerEnd int) bool {
+	return outerStart <= innerStart && innerEnd <= outerEnd
+}
+
+// OverlapSize returns the number of overlapping chapters between two ranges, or 0 if none
+func OverlapSize(a1, a2, b1, b2 int) int {
+	start := a1
+	if b1 > start {
+		start = b1
+	}
+	end := a2
+	if b2 < end {
+		end = b2
+	}
+	if start > end {
+		return 0
+	}
+	return end - start + 1
+}
+
+// RangeSize returns the span of a range
+func RangeSize(start, end int) int {
+	return end - start + 1
+}
+
+// FindMatchingEpisodes finds metadata episodes that match a torrent chapter range.
+// Returns all episodes where the overlap covers at least half of the smaller range.
+func FindMatchingEpisodes(chapterRange string, index *MetadataIndex) []MatchedEpisode {
+	if chapterRange == "" || index == nil {
+		return nil
+	}
+
+	norm := NormalizeRange(chapterRange)
+	tStart, tEnd := ParseRange(norm)
+	if tStart < 0 || tEnd < 0 {
+		return nil
+	}
+	tSize := RangeSize(tStart, tEnd)
+
+	var matches []MatchedEpisode
+
+	for seasonKey, season := range index.Seasons {
+		// Exact season range match
+		sNorm := NormalizeRange(season.Range)
+		if sNorm == norm {
+			logger.Log(false, "FindMatchingEpisodes: Exact season match found for chapterRange %s - %s", norm, seasonKey)
+			matches = append(matches, MatchedEpisode{
+				SeasonKey: seasonKey,
+				MatchType: MatchExact,
+			})
+			return matches
+		}
+
+		for epRange, epData := range season.EpisodeRange {
+			epNorm := NormalizeRange(epRange)
+
+			// Exact episode match
+			if epNorm == norm {
+				for _, ep := range epData {
+					logger.Log(false, "FindMatchingEpisodes(%s): Exact episode match found %s - %s", norm, seasonKey, ep.Title)
+					matches = append(matches, MatchedEpisode{
+						SeasonKey:    seasonKey,
+						EpisodeRange: epRange,
+						EpisodeTitle: ep.Title,
+						MatchType:    MatchExact,
+					})
+				}
+				return matches
+			}
+
+			// Overlap check
+			eStart, eEnd := ParseRange(epNorm)
+			if eStart < 0 || eEnd < 0 {
+				continue
+			}
+
+			overlap := OverlapSize(tStart, tEnd, eStart, eEnd)
+			if overlap == 0 {
+				continue
+			}
+
+			eSize := RangeSize(eStart, eEnd)
+			smallerSize := tSize
+			if eSize < smallerSize {
+				smallerSize = eSize
+			}
+
+			// Require overlap covers >50% of the smaller range
+			if overlap*2 >= smallerSize {
+				matchType := MatchOverlap
+				if RangeContains(tStart, tEnd, eStart, eEnd) {
+					matchType = MatchContains
+				} else if RangeContains(eStart, eEnd, tStart, tEnd) {
+					matchType = MatchContainedBy
+				}
+				for _, ep := range epData {
+					logger.Log(false, "FindMatchingEpisodes(%s): Overlap episode match (%d) found for chapterRange %s - %s - %s", norm, matchType, epRange, seasonKey, ep.Title)
+					matches = append(matches, MatchedEpisode{
+						SeasonKey:    seasonKey,
+						EpisodeRange: epRange,
+						EpisodeTitle: ep.Title,
+						MatchType:    matchType,
+					})
+				}
+			}
+		}
+	}
+
+	return matches
+}
+
+// MatchType describes how a torrent range matched a metadata range
+type MatchType int
+
+const (
+	MatchExact       MatchType = iota // ranges are identical
+	MatchContains                     // torrent contains the metadata episode
+	MatchContainedBy                  // metadata episode contains the torrent
+	MatchOverlap                      // significant partial overlap
+)
+
+// MatchedEpisode represents a metadata episode that matched a torrent range
+type MatchedEpisode struct {
+	SeasonKey    string
+	EpisodeRange string
+	EpisodeTitle string
+	MatchType    MatchType
 }

--- a/internal/shared/parsers.go
+++ b/internal/shared/parsers.go
@@ -40,6 +40,11 @@ func ExtractChapterRangeFromTitle(title string) string {
 
 // extracts the two ints separated by "-"
 func ParseRange(r string) (int, int) {
+	// if no dash exists, it should be a range of a single number
+	if !strings.Contains(r, "-") {
+		a, _ := strconv.Atoi(r)
+		return a, a
+	}
 	parts := strings.Split(r, "-")
 	if len(parts) != 2 {
 		return -1, -1

--- a/internal/shared/types.go
+++ b/internal/shared/types.go
@@ -39,6 +39,18 @@ type MetadataIndex struct {
 	Seasons map[string]SeasonIndex `json:"seasons"`
 }
 
+type SortedMetadataIndex struct {
+	Seasons []SeasonEntry `json:"seasons"`
+}
+
+// used for sorting MetadataIndex.Seasons
+// Title is equivalent to the key in the map
+// SeasonIndex is the associated value
+type SeasonEntry struct {
+	Title       string      `json:"title"`
+	SeasonIndex SeasonIndex `json:"index"`
+}
+
 // seasons maps episodes
 type SeasonIndex struct {
 	Range        string                 `json:"range"`

--- a/internal/shared/types.go
+++ b/internal/shared/types.go
@@ -28,6 +28,7 @@ type ScraperFields struct {
 	TorrentLink string `json:"torrent_link"`
 	TorrentID   string `json:"torrent_id"`
 	UploadDate  string `json:"upload_date"`
+	FileSize 		string `json:"file_size"`
 }
 
 type ValidationConfig struct {
@@ -55,7 +56,7 @@ type SeasonEntry struct {
 type SeasonIndex struct {
 	Range        string                 `json:"range"`
 	Name         string                 `json:"name"`
-	EpisodeRange map[string]EpisodeData `json:"episodes"`
+	EpisodeRange map[string][]EpisodeData `json:"episodes"`
 }
 
 // episodes maps titles and have
@@ -63,19 +64,24 @@ type EpisodeData struct {
 	Title string `json:"title"`
 }
 
+type FilePlacement struct {
+	Title             string   // title for display
+	FullTitle         string   // full file title
+	ChapterRange      string   // Main
+	PlacementFull     []string // used to display placed messages after all placements are done
+	PlacementProgress string   // used for placement messages after once placement is started
+	Placed            bool     // set to true when files are placed
+}
+
 // download struct
 type TorrentDownload struct {
-	Title             string    // title for display
-	FullTitle         string    // full torrent title
-	TorrentID         int       // torrentID for tempdir
-	ChapterRange      string    // Main
-	Started           time.Time // time torrent started (unused?)
-	Progress          int64     // used by ui progressbar
-	TotalSize         int64     // used by ui progress bar
-	PlacementFull     []string  // used to display placed messages after all placements are done
-	PlacementProgress string    //used for placement messages after download is done
-	Done              bool      // set to true when torrent is downloaded
-	Placed            bool      // set to true when files are placed, before clearing active downloads
+	FilePlacement
+	Entry 		TorrentEntry  // fields from TorrentEntry for easy access during placement
+	TorrentID int       		// torrentID for tempdir
+	Started   time.Time 		// time torrent started (unused?)
+	Progress  int64     		// used by ui progressbar
+	TotalSize int64     		// used by ui progress bar
+	Done      bool      		// set to true when torrent is downloaded
 }
 
 // entry for dl
@@ -92,6 +98,7 @@ type TorrentEntry struct {
 	MetaDataAvail bool   // metadata matching chapter range exists
 	IsSpecial     bool   // is a special (no chapter range)
 	HaveIt        int    // video with same chapter range exists
-	Date          string //
+	Date          time.Time // the upload date of the torrent, used for sorting and display
+	FileSize			string // file size as displayed on the torrent site
 	IsExtended    bool   // extended version
 }

--- a/internal/torrent/handledownloadsession.go
+++ b/internal/torrent/handledownloadsession.go
@@ -43,11 +43,14 @@ func HandleDownloadSession(entries []shared.TorrentEntry, outDir string) {
 		title := ui.StyleFactory(entry.TorrentName, ui.Style.LBlue)
 
 		td := &shared.TorrentDownload{
-			Title:        fmt.Sprintf("%s: %s (%s)", dKey, title, entry.Quality),
+			FilePlacement: shared.FilePlacement{
+				Title:        fmt.Sprintf("%s: %s (%s)", dKey, title, entry.Quality),
+				FullTitle:    entry.Title,
+				ChapterRange: entry.ChapterRange,
+			},
+			Entry: 				entry,
 			TorrentID:    entry.TorrentID,
-			FullTitle:    entry.Title,
 			Started:      time.Now(),
-			ChapterRange: entry.ChapterRange,
 		}
 
 		shared.SaveTorrentDownload(td)

--- a/internal/ui/stylefactory.go
+++ b/internal/ui/stylefactory.go
@@ -165,7 +165,7 @@ func AnsiPadRight(text string, width int, taila ...string) string {
 		tail = taila[0]
 	}
 	trunc := ansi.Truncate(text, width, tail)
-	visible := runewidth.StringWidth(trunc)
+	visible := runewidth.StringWidth(ansi.Strip(trunc))
 	if visible < width {
 		trunc += strings.Repeat(" ", width-visible)
 	}


### PR DESCRIPTION
The season "The Trials of Koby-Meppo" (Ch. 83-119) have chapters that overlap other seasons, causing some episodes from those other seasons to incorrectly match and be placed in "strayvideos".

This commit addresses that with these changes:

- Refactor season lookup logic in `matcher.go` to use sorted seasons
- Restart season lookup when no episode title is found
  - only place the episode in "strayvideos" if no seasons can find the episode title

_First time using Go, so I'm sure there are a number of things I could improve. Please let me know if you have any suggestions._