### PR TITLE
Add ability to pass ranges of download keys

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"strconv"
 
 	"opforjellyfin/internal/logger"
 	"opforjellyfin/internal/scraper"
@@ -49,13 +48,16 @@ var downloadCmd = &cobra.Command{
 
 		// stop spinner
 		spinner.Stop()
+
+		// Parse arguments with range support (e.g., "10 11-15 20")
+		downloadKeys, err := shared.ParseIntListWithRanges(args)
+		if err != nil {
+			logger.Log(true, "❌ Invalid syntax: %v", args)
+			return
+		}
+
 		var matches []shared.TorrentEntry
-		for _, arg := range args {
-			num, err := strconv.Atoi(arg)
-			if err != nil {
-				logger.Log(true, "❌ Invalid syntax: %s", arg)
-				return
-			}
+		for _, num := range downloadKeys {
 
 			// sort
 			var match *shared.TorrentEntry

--- a/internal/shared/parsers.go
+++ b/internal/shared/parsers.go
@@ -130,3 +130,41 @@ func NormalizeDash(s string) string {
 	// Replace en-dash and em-dash with hyphen-minus
 	return strings.NewReplacer("–", "-", "—", "-").Replace(s)
 }
+
+// ParseIntListWithRanges parses a list of arguments that can be integers or ranges.
+// e.g. ["10", "11-15", "20"] returns [10, 11, 12, 13, 14, 15, 20], nil
+func ParseIntListWithRanges(args []string) ([]int, error) {
+	var result []int
+	for _, arg := range args {
+		arg = NormalizeDash(arg)
+		if strings.Contains(arg, "-") {
+			// It's a range
+			parts := strings.Split(arg, "-")
+			if len(parts) != 2 {
+				return nil, fmt.Errorf("invalid range syntax: %s", arg)
+			}
+			start, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+			if err != nil {
+				return nil, fmt.Errorf("invalid range start: %s", arg)
+			}
+			end, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+			if err != nil {
+				return nil, fmt.Errorf("invalid range end: %s", arg)
+			}
+			if start > end {
+				return nil, fmt.Errorf("invalid range: start > end in %s", arg)
+			}
+			for i := start; i <= end; i++ {
+				result = append(result, i)
+			}
+		} else {
+			// Single integer
+			num, err := strconv.Atoi(strings.TrimSpace(arg))
+			if err != nil {
+				return nil, fmt.Errorf("invalid number: %s", arg)
+			}
+			result = append(result, num)
+		}
+	}
+	return result, nil
+}


### PR DESCRIPTION
Allows passing a range of download keys as a parameter to the download command e.g. "1 2-5 6" would download 1,2,3,4,5,6