### PR TITLE
Added NixOs support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ build.sh
 config.json
 testDir
 unused.old
-
+result

--- a/README.md
+++ b/README.md
@@ -78,6 +78,26 @@ MacOS / Linux:
 
 3. Run with `./opfor --help` to get started.
 
+NixOs:
+1. Add this to your flake inputs:
+   ```nix
+   opforjellyfin = {
+    url = "github:tissla/opforjellyfin";
+   #Optional, if you aren't in nix unstable channel and you get an error remove this line
+    inputs.nixpkgs.follows = "nixpkgs";
+    };
+   ```
+2. Add it to your packages; here's an example:
+   ```nix
+   { pkgs, system, opforjellyfin, ... }:
+   #x86_64 only at the moment
+   {
+     environment.systemPackages = [
+       (opforjellyfin.packages.${system}.default)
+      ];
+   }
+   ```
+
 Windows:
 
 1. Download the .exe file.

--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ NixOs:
    ```
 2. Add it to your packages; here's an example:
    ```nix
-   { pkgs, system, opforjellyfin, ... }:
+   { pkgs, inputs, ... }:
    #x86_64 only at the moment
    {
      environment.systemPackages = [
-       (opforjellyfin.packages.${system}.default)
+       (inputs.opforjellyfin.packages.${pkgs.system}.default)
       ];
    }
    ```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ MacOS / Linux:
 
 3. Run with `./opfor --help` to get started.
 
-NixOs:
+NixOS:
 1. Add this to your flake inputs:
    ```nix
    opforjellyfin = {

--- a/default.nix
+++ b/default.nix
@@ -15,6 +15,10 @@ buildGoModule rec {
   nativeBuildInputs = [ git ];
   propagatedBuildInputs = [ git ];
 
+  postInstall = ''
+    mv $out/bin/opforjellyfin $out/bin/opfor
+  '';
+
   meta = with lib; {
     description = "CLI to automate download and organisation of One Pace episodes for Jellyfin";
     homepage = "https://github.com/tissla/opforjellyfin";

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, buildGoModule, fetchFromGitHub, git }:
+
+buildGoModule rec {
+  pname = "opforjellyfin";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "tissla";
+    repo = "opforjellyfin";
+    rev = "d6133d89836c9c727438794ab634f6a2b1184540";
+    hash = "sha256-lSB+F7heenXEmr6T+PKTRC9ZLEPGMcG5nEtVTzJUe+A=";
+  };
+
+  vendorHash = "sha256-PL42t4SywbXmpPtetau03AsTHAGmhOrajsSyF4LJwUU=";
+  nativeBuildInputs = [ git ];
+  propagatedBuildInputs = [ git ];
+
+  meta = with lib; {
+    description = "CLI to automate download and organisation of One Pace episodes for Jellyfin";
+    homepage = "https://github.com/tissla/opforjellyfin";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ nahieluniversal ];
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1773258422,
@@ -17,7 +35,23 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773258422,
+        "narHash": "sha256-3SiI5zOYqX8fpU5R0soSKA73AHDxHQrCin+cJfY7GFg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5958f9c3387b4b09f4d5818f659d0728674beca2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -20,15 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773258422,
-        "narHash": "sha256-3SiI5zOYqX8fpU5R0soSKA73AHDxHQrCin+cJfY7GFg=",
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5958f9c3387b4b09f4d5818f659d0728674beca2",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776548001,
-        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "OpforJellyfin is a CLI tool to automate the download and organization of One Pace episodes for Jellyfin.";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";  # o un commit específico
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -3,17 +3,17 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs }: {
-    packages = {
-      x86_64-linux = {
-        default = let
-          pkgs = import nixpkgs {
-            system = "x86_64-linux";
-          };
-        in pkgs.callPackage ./default.nix { };
-      };
-    };
-  };
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+      in {
+        packages.default = pkgs.callPackage ./default.nix { };
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "OpforJellyfin is a CLI tool to automate the download and organization of One Pace episodes for Jellyfin.";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";  # o un commit específico
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,19 @@
+{
+  description = "OpforJellyfin is a CLI tool to automate the download and organization of One Pace episodes for Jellyfin.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+  };
+
+  outputs = { self, nixpkgs }: {
+    packages = {
+      x86_64-linux = {
+        default = let
+          pkgs = import nixpkgs {
+            system = "x86_64-linux";
+          };
+        in pkgs.callPackage ./default.nix { };
+      };
+    };
+  };
+}


### PR DESCRIPTION
I'm a NixOs user, my main linux distro. I wanted to use this program but because NixOS isn't POSIX compliant, the normal linux build can't find the libraries, so I created a nix flake (one of the main ways to install programs on nix) to be able to use it. I also edited the README file to add instructions to add the flake (most nix users probably know how but you never know if someone tries to install this without experience). Also this shouldn't be too difficult to maintain for a NixOs user, since it's just updating the hash and the commit hash. If this gets accepted I will probably open pull requests for new versions. (Btw I was working in this repo before doing the fork if you want to check that out too: [https://github.com/nahieluniversal/opforjellyfin_nix](https://github.com/nahieluniversal/opforjellyfin_nix) )