### PR TITLE
Add episode range download and deletion features

### DIFF
--- a/cmd/arcargs.go
+++ b/cmd/arcargs.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"strconv"
+	"strings"
+)
+
+func positionalArcName(args []string) (string, bool) {
+	if len(args) == 0 || allNumericRangeArgs(args) {
+		return "", false
+	}
+
+	return strings.Join(args, " "), true
+}
+
+func allNumericRangeArgs(args []string) bool {
+	for _, arg := range args {
+		if !isNumericRangeArg(arg) {
+			return false
+		}
+	}
+	return true
+}
+
+func isNumericRangeArg(arg string) bool {
+	if arg == "" {
+		return false
+	}
+
+	if !strings.Contains(arg, "-") {
+		_, err := strconv.Atoi(arg)
+		return err == nil
+	}
+
+	parts := strings.Split(arg, "-")
+	if len(parts) != 2 {
+		return false
+	}
+
+	_, startErr := strconv.Atoi(parts[0])
+	_, endErr := strconv.Atoi(parts[1])
+	return startErr == nil && endErr == nil
+}

--- a/cmd/arcargs_test.go
+++ b/cmd/arcargs_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import "testing"
+
+func TestPositionalArcName(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		want    string
+		wantArc bool
+	}{
+		{name: "download key", args: []string{"15"}, wantArc: false},
+		{name: "download key range", args: []string{"15-17"}, wantArc: false},
+		{name: "quoted arc", args: []string{"Long Ring Long Land"}, want: "Long Ring Long Land", wantArc: true},
+		{name: "unquoted arc", args: []string{"Long", "Ring", "Long", "Land"}, want: "Long Ring Long Land", wantArc: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotArc := positionalArcName(tt.args)
+			if gotArc != tt.wantArc {
+				t.Fatalf("gotArc = %v, want %v", gotArc, tt.wantArc)
+			}
+			if got != tt.want {
+				t.Fatalf("got = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"opforjellyfin/internal/metadata"
+	"opforjellyfin/internal/shared"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	deleteYes    bool
+	deleteDryRun bool
+	deleteArc    string
+)
+
+var deleteCmd = &cobra.Command{
+	Use:     "delete <chapterRange>|<arcName> [chapterRange|arcName...]",
+	Aliases: []string{"remove", "rm"},
+	Short:   "Delete downloaded episode video files",
+	Example: "opfor delete 15\nopfor delete 15-15 25-27 --yes\nopfor delete Skypia --dry-run",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if deleteArc == "" && len(args) == 0 {
+			return fmt.Errorf("requires at least one chapter range or --arc")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg := shared.LoadConfig()
+		if cfg.TargetDir == "" {
+			fmt.Println("No target directory set. Use 'setDir' first.")
+			return
+		}
+
+		index := metadata.LoadMetadataCache()
+		if index == nil || len(index.Seasons) == 0 {
+			fmt.Println("No metadata index found. Run 'sync' first.")
+			return
+		}
+
+		effectiveArc := deleteArc
+		if effectiveArc == "" {
+			if positionalName, ok := positionalArcName(args); ok {
+				effectiveArc = positionalName
+				args = nil
+			}
+		}
+
+		if effectiveArc != "" {
+			arc, err := metadata.FindArc(index, effectiveArc)
+			if err != nil {
+				fmt.Printf("Error: %v\n", err)
+				return
+			}
+
+			args = arc.EpisodeRanges
+			fmt.Printf("Matched arc %s (%s), chapters %s.\n", arc.Name, arc.Season, arc.Range)
+		}
+
+		candidates, missing, err := metadata.FindEpisodeVideosForDelete(cfg.TargetDir, index, args)
+		if err != nil {
+			fmt.Printf("Error: %v\n", err)
+			return
+		}
+
+		for _, chapterRange := range missing {
+			fmt.Printf("No metadata episode found for chapter range %s\n", chapterRange)
+		}
+
+		if len(candidates) == 0 {
+			fmt.Println("No downloaded episode videos found to delete.")
+			return
+		}
+
+		fmt.Println("Episode videos selected for deletion:")
+		for _, candidate := range candidates {
+			relPath, err := filepath.Rel(cfg.TargetDir, candidate.Path)
+			if err != nil {
+				relPath = candidate.Path
+			}
+			fmt.Printf("   - %s (%s): %s\n", candidate.ChapterRange, candidate.Season, relPath)
+		}
+
+		if deleteDryRun {
+			fmt.Println("Dry run only. No files were deleted.")
+			return
+		}
+
+		if !deleteYes && !confirmDelete(len(candidates)) {
+			fmt.Println("Cancelled.")
+			return
+		}
+
+		if err := metadata.DeleteEpisodeVideos(candidates); err != nil {
+			fmt.Printf("Error: %v\n", err)
+			return
+		}
+
+		fmt.Printf("Deleted %d episode video file(s).\n", len(candidates))
+	},
+}
+
+func confirmDelete(count int) bool {
+	fmt.Printf("Delete %d file(s)? Type yes to continue: ", count)
+
+	reader := bufio.NewReader(os.Stdin)
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+
+	return strings.EqualFold(strings.TrimSpace(answer), "yes")
+}
+
+func init() {
+	deleteCmd.Flags().BoolVarP(&deleteYes, "yes", "y", false, "Delete without asking for confirmation")
+	deleteCmd.Flags().BoolVar(&deleteDryRun, "dry-run", false, "Show files that would be deleted without deleting them")
+	deleteCmd.Flags().StringVarP(&deleteArc, "arc", "a", "", "Delete downloaded episode videos for an arc name")
+	rootCmd.AddCommand(deleteCmd)
+}

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"opforjellyfin/internal/logger"
 	"opforjellyfin/internal/scraper"
@@ -31,6 +32,12 @@ var downloadCmd = &cobra.Command{
 			return
 		}
 
+		expandedArgs, err := expandEpisodeArgs(args)
+		if err != nil {
+			logger.Log(true, "❌ %v", err)
+			return
+		}
+
 		cfg := shared.LoadConfig()
 		if cfg.TargetDir == "" {
 			logger.Log(true, "⚠️ No target directory set. Use 'setDir <path>' first.")
@@ -50,7 +57,7 @@ var downloadCmd = &cobra.Command{
 		// stop spinner
 		spinner.Stop()
 		var matches []shared.TorrentEntry
-		for _, arg := range args {
+		for _, arg := range expandedArgs {
 			num, err := strconv.Atoi(arg)
 			if err != nil {
 				logger.Log(true, "❌ Invalid syntax: %s", arg)
@@ -76,7 +83,7 @@ var downloadCmd = &cobra.Command{
 
 			// maybe rewrite this part
 			if forceKey != "" {
-				if len(args) > 1 {
+				if len(expandedArgs) > 1 {
 					logger.Log(true, "❌ --forcekey may only be used with a single DownloadKey")
 				}
 				match.ChapterRange = forceKey
@@ -105,4 +112,40 @@ func init() {
 	downloadCmd.Flags().StringVar(&forceKey, "forcekey", "", "Override chapter range (only for single downloadKey)")
 
 	rootCmd.AddCommand(downloadCmd)
+}
+
+// expandEpisodeArgs takes raw CLI arguments and expands range formats (like "15-17").
+func expandEpisodeArgs(args []string) ([]string, error) {
+	var expanded []string
+
+	for _, arg := range args {
+		// If the argument contains a hyphen, treat it as a range
+		if strings.Contains(arg, "-") {
+			parts := strings.Split(arg, "-")
+			if len(parts) != 2 {
+				return nil, fmt.Errorf("invalid range format: %s", arg)
+			}
+			
+			// Parse the start and end of the range
+			start, err1 := strconv.Atoi(parts[0])
+			end, err2 := strconv.Atoi(parts[1])
+			
+			if err1 != nil || err2 != nil {
+				return nil, fmt.Errorf("range must contain valid numbers: %s", arg)
+			}
+			if start > end {
+				return nil, fmt.Errorf("range start cannot be greater than range end: %s", arg)
+			}
+			
+			// Expand the range and append each episode to our result list
+			for i := start; i <= end; i++ {
+				expanded = append(expanded, strconv.Itoa(i))
+			}
+		} else {
+			// If it's a normal single number, just append it
+			expanded = append(expanded, arg)
+		}
+	}
+
+	return expanded, nil
 }

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -3,10 +3,12 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
 	"opforjellyfin/internal/logger"
+	"opforjellyfin/internal/metadata"
 	"opforjellyfin/internal/scraper"
 	"opforjellyfin/internal/shared"
 	"opforjellyfin/internal/torrent"
@@ -17,26 +19,25 @@ import (
 
 var (
 	forceKey string
+	arcName  string
 )
 
 var downloadCmd = &cobra.Command{
-	Use:   "download <downloadKey> [downloadKey...]",
+	Use:   "download <downloadKey>|<arcName> [downloadKey|arcName...]",
 	Short: "Download one or more One Pace torrents",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if arcName == "" && len(args) == 0 {
+			return fmt.Errorf("requires at least one download-key or --arc")
+		}
+		if arcName != "" && forceKey != "" {
+			return fmt.Errorf("--forcekey cannot be used with --arc")
+		}
+		return nil
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 
 		// add spinner
 		spinner := ui.NewSpinner("🗃️ Preparing download.. ", ui.Animations["MetaFetcher"])
-
-		if len(args) < 1 {
-			logger.Log(true, "⚠️ You must specify atleast one download-key")
-			return
-		}
-
-		expandedArgs, err := expandEpisodeArgs(args)
-		if err != nil {
-			logger.Log(true, "❌ %v", err)
-			return
-		}
 
 		cfg := shared.LoadConfig()
 		if cfg.TargetDir == "" {
@@ -56,6 +57,51 @@ var downloadCmd = &cobra.Command{
 
 		// stop spinner
 		spinner.Stop()
+
+		effectiveArc := arcName
+		if effectiveArc == "" {
+			if positionalName, ok := positionalArcName(args); ok {
+				effectiveArc = positionalName
+				args = nil
+			}
+		}
+
+		if effectiveArc != "" {
+			index := metadata.LoadMetadataCache()
+			if index == nil || len(index.Seasons) == 0 {
+				logger.Log(true, "⚠️ No metadata index found. Please run 'sync'")
+				return
+			}
+
+			arc, err := metadata.FindArc(index, effectiveArc)
+			if err != nil {
+				logger.Log(true, "❌ %v", err)
+				return
+			}
+
+			matches := selectArcDownloads(torrentList, arc)
+			if len(matches) == 0 {
+				logger.Log(true, "⚠️ No torrents found for arc %s (%s)", arc.Name, arc.Range)
+				return
+			}
+
+			logger.Log(true, "🎬 Matched arc %s (%s), chapters %s", arc.Name, arc.Season, arc.Range)
+			for _, match := range matches {
+				dKey := ui.StyleFactory(fmt.Sprintf("%4d", match.DownloadKey), ui.Style.Pink)
+				title := ui.StyleFactory(match.TorrentName, ui.Style.LBlue)
+				logger.Log(true, "🔍 Matched DownloadKey %s → %s (%s) [%s]", dKey, title, match.Quality, match.ChapterRange)
+			}
+
+			torrent.HandleDownloadSession(matches, cfg.TargetDir)
+			return
+		}
+
+		expandedArgs, err := expandEpisodeArgs(args)
+		if err != nil {
+			logger.Log(true, "❌ %v", err)
+			return
+		}
+
 		var matches []shared.TorrentEntry
 		for _, arg := range expandedArgs {
 			num, err := strconv.Atoi(arg)
@@ -110,8 +156,83 @@ var downloadCmd = &cobra.Command{
 
 func init() {
 	downloadCmd.Flags().StringVar(&forceKey, "forcekey", "", "Override chapter range (only for single downloadKey)")
+	downloadCmd.Flags().StringVarP(&arcName, "arc", "a", "", "Download all torrents for an arc name")
 
 	rootCmd.AddCommand(downloadCmd)
+}
+
+type rangedTorrentEntry struct {
+	entry shared.TorrentEntry
+	start int
+	end   int
+}
+
+func selectArcDownloads(torrentList []shared.TorrentEntry, arc *metadata.ArcMatch) []shared.TorrentEntry {
+	arcStart, arcEnd := shared.ParseRange(arc.Range)
+	if arcStart < 0 || arcEnd < 0 {
+		return nil
+	}
+
+	bestByRange := make(map[string]rangedTorrentEntry)
+	for _, entry := range torrentList {
+		if entry.IsSpecial || entry.ChapterRange == "" {
+			continue
+		}
+
+		start, end := shared.ParseRange(entry.ChapterRange)
+		if start < arcStart || end > arcEnd || start < 0 || end < 0 {
+			continue
+		}
+
+		rangeKey := shared.NormalizeDash(entry.ChapterRange)
+		current, exists := bestByRange[rangeKey]
+		if !exists || entry.Seeders > current.entry.Seeders {
+			bestByRange[rangeKey] = rangedTorrentEntry{
+				entry: entry,
+				start: start,
+				end:   end,
+			}
+		}
+	}
+
+	var candidates []rangedTorrentEntry
+	for _, candidate := range bestByRange {
+		candidates = append(candidates, candidate)
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].start == candidates[j].start {
+			iLen := candidates[i].end - candidates[i].start
+			jLen := candidates[j].end - candidates[j].start
+			if iLen == jLen {
+				return candidates[i].entry.Seeders > candidates[j].entry.Seeders
+			}
+			return iLen > jLen
+		}
+		return candidates[i].start < candidates[j].start
+	})
+
+	covered := make(map[int]bool)
+	var selected []shared.TorrentEntry
+	for _, candidate := range candidates {
+		overlapsSelected := false
+		for chapter := candidate.start; chapter <= candidate.end; chapter++ {
+			if covered[chapter] {
+				overlapsSelected = true
+				break
+			}
+		}
+		if overlapsSelected {
+			continue
+		}
+
+		selected = append(selected, candidate.entry)
+		for chapter := candidate.start; chapter <= candidate.end; chapter++ {
+			covered[chapter] = true
+		}
+	}
+
+	return selected
 }
 
 // expandEpisodeArgs takes raw CLI arguments and expands range formats (like "15-17").
@@ -125,18 +246,18 @@ func expandEpisodeArgs(args []string) ([]string, error) {
 			if len(parts) != 2 {
 				return nil, fmt.Errorf("invalid range format: %s", arg)
 			}
-			
+
 			// Parse the start and end of the range
 			start, err1 := strconv.Atoi(parts[0])
 			end, err2 := strconv.Atoi(parts[1])
-			
+
 			if err1 != nil || err2 != nil {
 				return nil, fmt.Errorf("range must contain valid numbers: %s", arg)
 			}
 			if start > end {
 				return nil, fmt.Errorf("range start cannot be greater than range end: %s", arg)
 			}
-			
+
 			// Expand the range and append each episode to our result list
 			for i := start; i <= end; i++ {
 				expanded = append(expanded, strconv.Itoa(i))

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"testing"
+
+	"opforjellyfin/internal/metadata"
+	"opforjellyfin/internal/shared"
+)
+
+func TestSelectArcDownloadsPicksHighestSeededNonOverlappingRanges(t *testing.T) {
+	arc := &metadata.ArcMatch{
+		Name:   "Long Ring Long Land",
+		Season: "Season 5",
+		Range:  "303-321",
+	}
+
+	torrents := []shared.TorrentEntry{
+		{DownloadKey: 1, ChapterRange: "303-303", Seeders: 3, TorrentName: "low"},
+		{DownloadKey: 2, ChapterRange: "303-303", Seeders: 10, TorrentName: "high"},
+		{DownloadKey: 3, ChapterRange: "304-305", Seeders: 4, TorrentName: "bundle"},
+		{DownloadKey: 4, ChapterRange: "304-304", Seeders: 100, TorrentName: "overlap"},
+		{DownloadKey: 5, ChapterRange: "400-401", Seeders: 50, TorrentName: "outside"},
+	}
+
+	selected := selectArcDownloads(torrents, arc)
+	if len(selected) != 2 {
+		t.Fatalf("len(selected) = %d, want 2", len(selected))
+	}
+	if selected[0].DownloadKey != 2 {
+		t.Fatalf("selected[0].DownloadKey = %d, want 2", selected[0].DownloadKey)
+	}
+	if selected[1].DownloadKey != 3 {
+		t.Fatalf("selected[1].DownloadKey = %d, want 3", selected[1].DownloadKey)
+	}
+}

--- a/internal/metadata/arcs.go
+++ b/internal/metadata/arcs.go
@@ -1,0 +1,183 @@
+package metadata
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"opforjellyfin/internal/shared"
+)
+
+type ArcMatch struct {
+	Season        string
+	Name          string
+	Range         string
+	EpisodeRanges []string
+}
+
+func FindArc(index *shared.MetadataIndex, query string) (*ArcMatch, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, fmt.Errorf("arc name cannot be empty")
+	}
+
+	arcs := sortedArcs(index)
+	if len(arcs) == 0 {
+		return nil, fmt.Errorf("no arcs found in metadata index")
+	}
+
+	normalizedQuery := normalizeArcQuery(query)
+
+	for _, arc := range arcs {
+		if normalizeArcQuery(arc.Name) == normalizedQuery || normalizeArcQuery(arc.Season) == normalizedQuery {
+			return &arc, nil
+		}
+	}
+
+	var matches []ArcMatch
+	for _, arc := range arcs {
+		if strings.Contains(normalizeArcQuery(arc.Name), normalizedQuery) {
+			matches = append(matches, arc)
+		}
+	}
+
+	if len(matches) == 1 {
+		return &matches[0], nil
+	}
+	if len(matches) > 1 {
+		return nil, fmt.Errorf("arc name %q matched multiple arcs: %s", query, formatArcNames(matches))
+	}
+
+	var closeMatches []ArcMatch
+	for _, arc := range arcs {
+		if levenshtein(normalizeArcQuery(arc.Name), normalizedQuery) <= 2 {
+			closeMatches = append(closeMatches, arc)
+		}
+	}
+	if len(closeMatches) == 1 {
+		return &closeMatches[0], nil
+	}
+
+	return nil, fmt.Errorf("no arc found matching %q", query)
+}
+
+func sortedArcs(index *shared.MetadataIndex) []ArcMatch {
+	var arcs []ArcMatch
+	if index == nil {
+		return arcs
+	}
+
+	for seasonKey, season := range index.Seasons {
+		name := season.Name
+		if name == "" {
+			name = seasonKey
+		}
+
+		var ranges []string
+		for epRange := range season.EpisodeRange {
+			ranges = append(ranges, shared.NormalizeDash(epRange))
+		}
+		sort.Slice(ranges, func(i, j int) bool {
+			iStart, _ := shared.ParseRange(ranges[i])
+			jStart, _ := shared.ParseRange(ranges[j])
+			return iStart < jStart
+		})
+
+		arcs = append(arcs, ArcMatch{
+			Season:        seasonKey,
+			Name:          name,
+			Range:         shared.NormalizeDash(season.Range),
+			EpisodeRanges: ranges,
+		})
+	}
+
+	sort.Slice(arcs, func(i, j int) bool {
+		return seasonSortValue(arcs[i].Season) < seasonSortValue(arcs[j].Season)
+	})
+
+	return arcs
+}
+
+func normalizeArcQuery(value string) string {
+	value = strings.ToLower(value)
+	var builder strings.Builder
+	for _, r := range value {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			builder.WriteRune(r)
+		}
+	}
+	return builder.String()
+}
+
+func formatArcNames(arcs []ArcMatch) string {
+	names := make([]string, 0, len(arcs))
+	for _, arc := range arcs {
+		names = append(names, fmt.Sprintf("%s (%s)", arc.Name, arc.Season))
+	}
+	return strings.Join(names, ", ")
+}
+
+func seasonSortValue(season string) int {
+	if season == "Specials" {
+		return 0
+	}
+
+	fields := strings.Fields(season)
+	if len(fields) != 2 {
+		return 9999
+	}
+
+	value, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return 9999
+	}
+	return value
+}
+
+func levenshtein(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if len(a) == 0 {
+		return len(b)
+	}
+	if len(b) == 0 {
+		return len(a)
+	}
+
+	prev := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+
+	for i := 1; i <= len(a); i++ {
+		current := make([]int, len(b)+1)
+		current[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 0
+			if a[i-1] != b[j-1] {
+				cost = 1
+			}
+			current[j] = minInt(
+				current[j-1]+1,
+				prev[j]+1,
+				prev[j-1]+cost,
+			)
+		}
+		prev = current
+	}
+
+	return prev[len(b)]
+}
+
+func minInt(values ...int) int {
+	min := values[0]
+	for _, value := range values[1:] {
+		if value < min {
+			min = value
+		}
+	}
+	return min
+}

--- a/internal/metadata/arcs_test.go
+++ b/internal/metadata/arcs_test.go
@@ -1,0 +1,51 @@
+package metadata
+
+import (
+	"testing"
+
+	"opforjellyfin/internal/shared"
+)
+
+func TestFindArcMatchesNameCaseInsensitively(t *testing.T) {
+	index := &shared.MetadataIndex{
+		Seasons: map[string]shared.SeasonIndex{
+			"Season 4": {
+				Name:  "Skypiea",
+				Range: "237-302",
+				EpisodeRange: map[string]shared.EpisodeData{
+					"237-238": {Title: "S04E01 - The Knock Up Stream"},
+				},
+			},
+		},
+	}
+
+	arc, err := FindArc(index, "skypiea")
+	if err != nil {
+		t.Fatalf("FindArc() error = %v", err)
+	}
+	if arc.Name != "Skypiea" {
+		t.Fatalf("arc.Name = %q, want Skypiea", arc.Name)
+	}
+}
+
+func TestFindArcAllowsCloseMisspelling(t *testing.T) {
+	index := &shared.MetadataIndex{
+		Seasons: map[string]shared.SeasonIndex{
+			"Season 4": {
+				Name:  "Skypiea",
+				Range: "237-302",
+				EpisodeRange: map[string]shared.EpisodeData{
+					"237-238": {Title: "S04E01 - The Knock Up Stream"},
+				},
+			},
+		},
+	}
+
+	arc, err := FindArc(index, "Skypia")
+	if err != nil {
+		t.Fatalf("FindArc() error = %v", err)
+	}
+	if arc.Name != "Skypiea" {
+		t.Fatalf("arc.Name = %q, want Skypiea", arc.Name)
+	}
+}

--- a/internal/metadata/delete.go
+++ b/internal/metadata/delete.go
@@ -1,0 +1,137 @@
+package metadata
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"opforjellyfin/internal/shared"
+)
+
+type DeleteCandidate struct {
+	ChapterRange string
+	Season       string
+	Title        string
+	Path         string
+}
+
+func FindEpisodeVideosForDelete(baseDir string, index *shared.MetadataIndex, chapterRanges []string) ([]DeleteCandidate, []string, error) {
+	var candidates []DeleteCandidate
+	var missing []string
+	seen := make(map[string]bool)
+
+	baseAbs, err := filepath.Abs(baseDir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not resolve target directory: %w", err)
+	}
+
+	for _, rawRange := range chapterRanges {
+		chapterRange, err := normalizeDeleteRange(rawRange)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		found := false
+		for seasonKey, season := range index.Seasons {
+			for epRange, ep := range season.EpisodeRange {
+				if shared.NormalizeDash(epRange) != chapterRange {
+					continue
+				}
+
+				found = true
+				for _, ext := range []string{".mp4", ".mkv"} {
+					path := filepath.Join(baseDir, seasonKey, ep.Title+ext)
+					if !shared.FileExists(path) {
+						continue
+					}
+
+					if err := ensurePathInDir(baseAbs, path); err != nil {
+						return nil, nil, err
+					}
+
+					if seen[path] {
+						continue
+					}
+					seen[path] = true
+
+					candidates = append(candidates, DeleteCandidate{
+						ChapterRange: chapterRange,
+						Season:       seasonKey,
+						Title:        ep.Title,
+						Path:         path,
+					})
+				}
+			}
+		}
+
+		if !found {
+			missing = append(missing, chapterRange)
+		}
+	}
+
+	return candidates, missing, nil
+}
+
+func DeleteEpisodeVideos(candidates []DeleteCandidate) error {
+	for _, candidate := range candidates {
+		if err := os.Remove(candidate.Path); err != nil {
+			return fmt.Errorf("failed to delete %s: %w", candidate.Path, err)
+		}
+	}
+
+	return nil
+}
+
+func normalizeDeleteRange(value string) (string, error) {
+	value = strings.TrimSpace(shared.NormalizeDash(value))
+	if value == "" {
+		return "", fmt.Errorf("empty chapter range")
+	}
+
+	if !strings.Contains(value, "-") {
+		chapter, err := strconv.Atoi(value)
+		if err != nil {
+			return "", fmt.Errorf("invalid chapter range: %s", value)
+		}
+		return fmt.Sprintf("%d-%d", chapter, chapter), nil
+	}
+
+	parts := strings.Split(value, "-")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid chapter range: %s", value)
+	}
+
+	start, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return "", fmt.Errorf("invalid chapter range: %s", value)
+	}
+	end, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return "", fmt.Errorf("invalid chapter range: %s", value)
+	}
+	if start > end {
+		return "", fmt.Errorf("range start cannot be greater than range end: %s", value)
+	}
+
+	return fmt.Sprintf("%d-%d", start, end), nil
+}
+
+func ensurePathInDir(baseAbs, path string) error {
+	pathAbs, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("could not resolve path %s: %w", path, err)
+	}
+
+	rel, err := filepath.Rel(baseAbs, pathAbs)
+	if err != nil {
+		return fmt.Errorf("could not compare %s to target directory: %w", path, err)
+	}
+
+	if rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." || filepath.IsAbs(rel) {
+		return fmt.Errorf("refusing to delete path outside target directory: %s", path)
+	}
+
+	return nil
+}

--- a/internal/metadata/delete_test.go
+++ b/internal/metadata/delete_test.go
@@ -1,0 +1,108 @@
+package metadata
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"opforjellyfin/internal/shared"
+)
+
+func TestFindEpisodeVideosForDelete(t *testing.T) {
+	baseDir := t.TempDir()
+	seasonDir := filepath.Join(baseDir, "Season 1")
+	if err := os.MkdirAll(seasonDir, 0755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	videoPath := filepath.Join(seasonDir, "S01E01 - Romance Dawn.mkv")
+	nfoPath := filepath.Join(seasonDir, "S01E01 - Romance Dawn.nfo")
+	for _, path := range []string{videoPath, nfoPath} {
+		if err := os.WriteFile(path, []byte("test"), 0644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+	}
+
+	index := &shared.MetadataIndex{
+		Seasons: map[string]shared.SeasonIndex{
+			"Season 1": {
+				Range: "1-7",
+				EpisodeRange: map[string]shared.EpisodeData{
+					"1-1": {Title: "S01E01 - Romance Dawn"},
+				},
+			},
+		},
+	}
+
+	candidates, missing, err := FindEpisodeVideosForDelete(baseDir, index, []string{"1"})
+	if err != nil {
+		t.Fatalf("FindEpisodeVideosForDelete() error = %v", err)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("missing = %v, want none", missing)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("len(candidates) = %d, want 1", len(candidates))
+	}
+	if candidates[0].Path != videoPath {
+		t.Fatalf("candidate path = %q, want %q", candidates[0].Path, videoPath)
+	}
+}
+
+func TestDeleteEpisodeVideosLeavesMetadata(t *testing.T) {
+	baseDir := t.TempDir()
+	seasonDir := filepath.Join(baseDir, "Season 1")
+	if err := os.MkdirAll(seasonDir, 0755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	videoPath := filepath.Join(seasonDir, "S01E01 - Romance Dawn.mp4")
+	nfoPath := filepath.Join(seasonDir, "S01E01 - Romance Dawn.nfo")
+	for _, path := range []string{videoPath, nfoPath} {
+		if err := os.WriteFile(path, []byte("test"), 0644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+	}
+
+	err := DeleteEpisodeVideos([]DeleteCandidate{{Path: videoPath}})
+	if err != nil {
+		t.Fatalf("DeleteEpisodeVideos() error = %v", err)
+	}
+	if shared.FileExists(videoPath) {
+		t.Fatalf("video file still exists after delete")
+	}
+	if !shared.FileExists(nfoPath) {
+		t.Fatalf("metadata file was deleted")
+	}
+}
+
+func TestFindEpisodeVideosForDeleteReportsMissingMetadata(t *testing.T) {
+	index := &shared.MetadataIndex{
+		Seasons: map[string]shared.SeasonIndex{
+			"Season 1": {
+				Range:        "1-7",
+				EpisodeRange: map[string]shared.EpisodeData{},
+			},
+		},
+	}
+
+	candidates, missing, err := FindEpisodeVideosForDelete(t.TempDir(), index, []string{"99"})
+	if err != nil {
+		t.Fatalf("FindEpisodeVideosForDelete() error = %v", err)
+	}
+	if len(candidates) != 0 {
+		t.Fatalf("len(candidates) = %d, want 0", len(candidates))
+	}
+	if len(missing) != 1 || missing[0] != "99-99" {
+		t.Fatalf("missing = %v, want [99-99]", missing)
+	}
+}
+
+func TestFindEpisodeVideosForDeleteRejectsInvalidRange(t *testing.T) {
+	index := &shared.MetadataIndex{Seasons: map[string]shared.SeasonIndex{}}
+
+	_, _, err := FindEpisodeVideosForDelete(t.TempDir(), index, []string{"1-x"})
+	if err == nil {
+		t.Fatalf("FindEpisodeVideosForDelete() error = nil, want error")
+	}
+}


### PR DESCRIPTION
This pull request introduces major new features to support arc-based operations in the CLI, including downloading and deleting episodes by arc name, as well as significant improvements to argument parsing, arc matching, and test coverage. The most important changes are summarized below.

---

**Arc-based Download and Delete Functionality**

* Added support for downloading (`download`) and deleting (`delete`) episodes by arc name, either via a new `--arc` flag or by providing an arc name positionally. This includes logic to match arc names, expand arc episode ranges, and select the best torrent candidates for a given arc. (`cmd/download.go` [[1]](diffhunk://#diff-b8944fec95ace1dda1413c3af82caa65ba87cee976b37ec7d34c31d5fdee441dR22-L33) [[2]](diffhunk://#diff-b8944fec95ace1dda1413c3af82caa65ba87cee976b37ec7d34c31d5fdee441dR60-R106) [[3]](diffhunk://#diff-b8944fec95ace1dda1413c3af82caa65ba87cee976b37ec7d34c31d5fdee441dL79-R132) [[4]](diffhunk://#diff-66295c91807b2a508ea26d2f00bc4e724a53dbdda0378fe886b08540d0369c10R1-R43); `cmd/delete.go` [[5]](diffhunk://#diff-f5260a77803d3f3b2d475b8a6faa7dc0d0325998efdd5a2684cb6b5bf3e7efa3R1-R125)

* Implemented the `selectArcDownloads` function to pick the highest-seeded, non-overlapping torrent entries for a given arc, ensuring optimal downloads. (`cmd/download.go` [cmd/download.goR159-R272](diffhunk://#diff-b8944fec95ace1dda1413c3af82caa65ba87cee976b37ec7d34c31d5fdee441dR159-R272))

* Added the `FindArc` function and supporting logic to robustly match arc names, including normalization, substring, and fuzzy (Levenshtein distance) matching, with clear error handling for ambiguous or missing arcs. (`internal/metadata/arcs.go` [internal/metadata/arcs.goR1-R183](diffhunk://#diff-50e8272103db1de164bbaa8e09ab9448e5351f8e3b034915bb4f46372e07b160R1-R183))

**Episode Deletion Support**

* Added a new `delete` CLI command that allows users to delete downloaded episode video files by chapter range or arc name, with dry-run and confirmation options. (`cmd/delete.go` [cmd/delete.goR1-R125](diffhunk://#diff-f5260a77803d3f3b2d475b8a6faa7dc0d0325998efdd5a2684cb6b5bf3e7efa3R1-R125))

* Implemented supporting logic to resolve episode video file paths, check for existence, and safely delete files only within the target directory. (`internal/metadata/delete.go` [internal/metadata/delete.goR1-R137](diffhunk://#diff-a6d26e2883309223f948d8258322b2a455145279f8f997e0447c6feab38b25ecR1-R137))

**Argument Parsing and Validation**

* Improved argument parsing for both download and delete commands, including expansion of numeric chapter ranges (e.g., `15-17`), and distinguishing between numeric/range and arc name arguments. (`cmd/arcargs.go` [[1]](diffhunk://#diff-66295c91807b2a508ea26d2f00bc4e724a53dbdda0378fe886b08540d0369c10R1-R43) `cmd/download.go` [[2]](diffhunk://#diff-b8944fec95ace1dda1413c3af82caa65ba87cee976b37ec7d34c31d5fdee441dR60-R106)

**Test Coverage**

* Added unit tests for arc name parsing, arc matching (including fuzzy matches), and the selection of torrent entries for arcs, improving reliability and maintainability. (`cmd/arcargs_test.go` [[1]](diffhunk://#diff-7777b83ba3e8195a8b3e140c9cffd6dfd5aefe5616ebc154581a1db31f69252fR1-R29) `cmd/download_test.go` [[2]](diffhunk://#diff-f49c5e810873f134b402d79e49a3a3c9969948a54be73e4359e401b633180d6fR1-R35) `internal/metadata/arcs_test.go` [[3]](diffhunk://#diff-ba794feea611acd5521aec91971d0dab74ff25fda9cf7c6d99a499069327eed1R1-R51)

---

These changes significantly enhance the user experience by allowing flexible and robust arc-based operations, improving both convenience and safety for episode management.